### PR TITLE
Add CaptainHook action to `composer install` after checkout

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -34,8 +34,24 @@
         "actions": []
     },
     "post-checkout": {
-        "enabled": false,
-        "actions": []
+        "enabled": true,
+        "actions": [
+            {
+                "action": "tools/composer install",
+                "options": [],
+                "conditions": [
+                    {
+                        "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileChanged\\Any",
+                        "args": [
+                            [
+                                "composer.json",
+                                "composer.lock"
+                            ]
+                        ]
+                    }
+                ]
+            }
+        ]
     },
     "post-rewrite": {
         "enabled": false,


### PR DESCRIPTION
If `composer.json` or `composer.lock` are changed by a checkout (for example checking out a new branch) run `composer install`.