### PR TITLE
Fix path to Composer in CaptainHook config

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -37,7 +37,7 @@
         "enabled": true,
         "actions": [
             {
-                "action": "tools/composer install",
+                "action": "composer install",
                 "options": [],
                 "conditions": [
                     {


### PR DESCRIPTION
It should be installed globally in most developers' systems.